### PR TITLE
no_autoflush while making a revision

### DIFF
--- a/eventframe/nodes/content/models.py
+++ b/eventframe/nodes/content/models.py
@@ -136,9 +136,10 @@ class ContentMixin(NodeMixin):
         if revision is None:
             # If parent is still None after this, there was no parent
             revision = self.last_revision()
-        new_revision = ContentRevision(parent=self.revisions, previous=revision)
-        self.revisions.draft = new_revision
-        db.session.add(new_revision)
+        with db.session.no_autoflush:
+            new_revision = ContentRevision(parent=self.revisions, previous=revision)
+            self.revisions.draft = new_revision
+            db.session.add(new_revision)
         return new_revision
 
     @property


### PR DESCRIPTION
`new_revision` is initiated inside a `no_autoflush` block to prevent flushing an incomplete revision object.